### PR TITLE
通信量集計時にloopback通信量を含まないように修正

### DIFF
--- a/app/src/main/java/jp/takke/datastats/MyTrafficUtil.java
+++ b/app/src/main/java/jp/takke/datastats/MyTrafficUtil.java
@@ -2,6 +2,11 @@ package jp.takke.datastats;
 
 import android.content.res.Resources;
 
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+
 public class MyTrafficUtil {
 
 
@@ -49,5 +54,45 @@ public class MyTrafficUtil {
             return resources.getColor(R.color.textColorMiddle);
         }
         return resources.getColor(R.color.textColorHigh);
+    }
+
+    static long getLoopbackRxBytes() {
+
+        long rxBytes = 0;
+        File file = new File("/sys/class/net/lo/statistics/rx_bytes");
+        try {
+            BufferedReader br = new BufferedReader(new FileReader(file));
+
+            String line;
+            if ((line = br.readLine()) != null) {
+                rxBytes = Long.valueOf(line);
+            }
+
+            br.close();
+        } catch (IOException e) {
+            rxBytes = 0;
+        }
+
+        return rxBytes;
+    }
+
+    static long getLoopbackTxBytes() {
+
+        long txBytes = 0;
+        File file = new File("/sys/class/net/lo/statistics/tx_bytes");
+        try {
+            BufferedReader br = new BufferedReader(new FileReader(file));
+
+            String line;
+            if ((line = br.readLine()) != null) {
+                txBytes = Long.valueOf(line);
+            }
+
+            br.close();
+        } catch (IOException e) {
+            txBytes = 0;
+        }
+
+        return txBytes;
     }
 }


### PR DESCRIPTION
Google Play Musicなどの音楽や動画の一部のアプリではloopback通信量が発生するが、内部通信なので通信速度の計算には含まないように修正した。